### PR TITLE
New: Implement DEBUG mode for logging in docgen (fixes #19)

### DIFF
--- a/bin/docgen.js
+++ b/bin/docgen.js
@@ -9,8 +9,10 @@ import jsdoc3 from '../jsdoc3/jsdoc3.js'
 import path from 'path'
 import swagger from '../swagger/swagger.js'
 
+const DEBUG = process.argv.includes('--verbose')
+
 process.env.NODE_ENV ??= 'production'
-process.env.ADAPT_AUTHORING_LOGGER__mute = true
+process.env.ADAPT_AUTHORING_LOGGER__mute = !DEBUG
 
 const app = App.instance
 let outputdir
@@ -68,7 +70,7 @@ async function copyRootFiles () {
 }
 
 async function docs () {
-  console.log(`Generating documentation for ${app.pkg.name}@${app.pkg.version}`)
+  console.log(`Generating documentation for ${app.pkg.name}@${app.pkg.version} ${DEBUG ? ' :: DEBUG' : ''}`)
 
   try {
     await app.onReady()


### PR DESCRIPTION
Added DEBUG mode to control logging behavior and modified console output to indicate debug status.

[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Add a link to the original issue)
#19 

[//]: # (Delete as appropriate)
### New
* Add --verbose flag to docgen for debug logging