### PR TITLE
Fix: Update manual sections (fixes #26)

### DIFF
--- a/adapt-authoring.json
+++ b/adapt-authoring.json
@@ -3,9 +3,11 @@
   "documentation": {
     "enable": true,
     "manualPages": {
-      "building-docs.md": "getting-started",
-      "custom-documentation-plugins.md": "advanced",
-      "writing-documentation.md": "contributing"
+      "building-docs.md": "documentation",
+      "custom-documentation-plugins.md": "documentation",
+      "jsdoc-guide.md": "documentation",
+      "rest-api-guide.md": "documentation",
+      "writing-documentation.md": "documentation"
     }
   }
 }


### PR DESCRIPTION
https://github.com/adapt-security/adapt-authoring-docs/issues/26

### Fix
* Updated manual page sections in adapt-authoring.json to use "documentation" section for all documentation pages
* Added jsdoc-guide.md and rest-api-guide.md to manual pages configuration